### PR TITLE
Gluten functional sweep

### DIFF
--- a/hudi-client/hudi-spark-client/pom.xml
+++ b/hudi-client/hudi-spark-client/pom.xml
@@ -31,10 +31,11 @@
 
   <dependencies>
     <!-- Gluten/Velox bundle (test only) for the data-type sweep. Installed into the local
-         Maven repo via `mvn install:install-file` from the prebuilt quanton-velox-bundle JAR. -->
+         Maven repo via `mvn install:install-file` from the prebuilt, non-rebranded
+         gluten-velox-bundle JAR (upstream org.apache.gluten namespace). -->
     <dependency>
       <groupId>org.apache.gluten</groupId>
-      <artifactId>quanton-velox-bundle</artifactId>
+      <artifactId>gluten-velox-bundle</artifactId>
       <version>1.5.1-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>

--- a/hudi-client/hudi-spark-client/pom.xml
+++ b/hudi-client/hudi-spark-client/pom.xml
@@ -30,6 +30,15 @@
   <packaging>jar</packaging>
 
   <dependencies>
+    <!-- Gluten/Velox bundle (test only) for the data-type sweep. Installed into the local
+         Maven repo via `mvn install:install-file` from the prebuilt quanton-velox-bundle JAR. -->
+    <dependency>
+      <groupId>org.apache.gluten</groupId>
+      <artifactId>quanton-velox-bundle</artifactId>
+      <version>1.5.1-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Scala -->
     <dependency>
       <groupId>org.scala-lang</groupId>

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
@@ -97,6 +97,32 @@ public class HoodieClientTestUtils {
         .set("spark.sql.shuffle.partitions", "4")
         .set("spark.default.parallelism", "4");
 
+    // Gluten/Velox sweep: gate behind -Dhudi.test.gluten.enabled=true so the harness can be
+    // flipped back to vanilla Spark without code changes.
+    //
+    // NOTE: the prebuilt bundle is Onehouse's "Quanton" rebrand of Gluten -- every upstream
+    // `org.apache.gluten.*` class and `spark.gluten.*` config is relocated to
+    // `ai.onehouse.quanton.*` / `spark.quanton.*`. The shuffle manager stays in org.apache.spark.
+    //
+    // Fallback handling: this Gluten version has NO throw-on-fallback config (the old
+    // spark.gluten.sql.columnar.fallback.enabled was removed). We approximate fail-loud by
+    // collapsing any partially-offloaded query fully back to vanilla (threshold=1) and turning
+    // on the fallback reporter + debug so the fallback reason is logged. See sweep notes.
+    if (Boolean.parseBoolean(System.getProperty("hudi.test.gluten.enabled", "false"))) {
+      sparkConf
+          .set("spark.plugins", "ai.onehouse.quanton.QuantonPlugin")
+          .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
+          .set("spark.memory.offHeap.enabled", "true")
+          .set("spark.memory.offHeap.size", "4g")
+          .set("spark.quanton.enabled", "true")
+          .set("spark.quanton.sql.columnar.libname", "gluten")
+          .set("spark.quanton.sql.columnar.query.fallback.threshold", "1")
+          .set("spark.quanton.sql.columnar.wholeStage.fallback.threshold", "1")
+          .set("spark.quanton.sql.columnar.fallbackReporter", "true")
+          .set("spark.quanton.sql.validation.printStackOnFailure", "true")
+          .set("spark.quanton.sql.debug", "true");
+    }
+
     // NOTE: This utility is used in modules where this class might not be present, therefore
     //       to avoid littering output w/ [[ClassNotFoundException]]s we will skip adding it
     //       in case this utility is used in the module not providing it

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
@@ -100,27 +100,27 @@ public class HoodieClientTestUtils {
     // Gluten/Velox sweep: gate behind -Dhudi.test.gluten.enabled=true so the harness can be
     // flipped back to vanilla Spark without code changes.
     //
-    // NOTE: the prebuilt bundle is Onehouse's "Quanton" rebrand of Gluten -- every upstream
-    // `org.apache.gluten.*` class and `spark.gluten.*` config is relocated to
-    // `ai.onehouse.quanton.*` / `spark.quanton.*`. The shuffle manager stays in org.apache.spark.
+    // Uses the consistent (non-rebranded) gluten-velox-bundle: upstream org.apache.gluten.*
+    // classes and spark.gluten.* configs. Shuffle manager stays in org.apache.spark.
     //
     // Fallback handling: this Gluten version has NO throw-on-fallback config (the old
-    // spark.gluten.sql.columnar.fallback.enabled was removed). We approximate fail-loud by
-    // collapsing any partially-offloaded query fully back to vanilla (threshold=1) and turning
-    // on the fallback reporter + debug so the fallback reason is logged. See sweep notes.
+    // spark.gluten.sql.columnar.fallback.enabled was removed). Instead we let Gluten offload
+    // what it can and keep the GlutenFallbackReporter on -- it logs each operator that cannot be
+    // offloaded together with the concrete reason (e.g. unsupported type/expression), which is
+    // the signal the data-type sweep parses. We deliberately do NOT set the fallback thresholds:
+    // forcing whole-query fallback (threshold=1) masks the per-operator reasons behind a generic
+    // "Fallback policy is taking effect" message. See sweep notes.
     if (Boolean.parseBoolean(System.getProperty("hudi.test.gluten.enabled", "false"))) {
       sparkConf
-          .set("spark.plugins", "ai.onehouse.quanton.QuantonPlugin")
+          .set("spark.plugins", "org.apache.gluten.GlutenPlugin")
           .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
           .set("spark.memory.offHeap.enabled", "true")
           .set("spark.memory.offHeap.size", "4g")
-          .set("spark.quanton.enabled", "true")
-          .set("spark.quanton.sql.columnar.libname", "gluten")
-          .set("spark.quanton.sql.columnar.query.fallback.threshold", "1")
-          .set("spark.quanton.sql.columnar.wholeStage.fallback.threshold", "1")
-          .set("spark.quanton.sql.columnar.fallbackReporter", "true")
-          .set("spark.quanton.sql.validation.printStackOnFailure", "true")
-          .set("spark.quanton.sql.debug", "true");
+          .set("spark.gluten.enabled", "true")
+          .set("spark.gluten.sql.columnar.libname", "gluten")
+          .set("spark.gluten.sql.columnar.fallbackReporter", "true")
+          .set("spark.gluten.sql.validation.printStackOnFailure", "true")
+          .set("spark.gluten.sql.debug", "true");
     }
 
     // NOTE: This utility is used in modules where this class might not be present, therefore

--- a/hudi-spark-datasource/hudi-spark/pom.xml
+++ b/hudi-spark-datasource/hudi-spark/pom.xml
@@ -117,6 +117,9 @@
         <artifactId>scalatest-maven-plugin</artifactId>
         <configuration>
           <tagsToExclude>org.apache.hudi.functional.SparkSQLCoreFlow</tagsToExclude>
+          <!-- Base JVM args plus the JNI ext-opens Gluten/Velox needs to reach
+               java.nio / sun.nio.ch / jdk.internal.misc off-heap memory. -->
+          <argLine>-Xmx3g -Xms128m -XX:-OmitStackTraceInFastThrow --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true</argLine>
         </configuration>
       </plugin>
       <plugin>
@@ -148,6 +151,16 @@
   </build>
 
   <dependencies>
+
+    <!-- Gluten/Velox bundle (test only) for the data-type sweep. Installed into the local
+         Maven repo via `mvn install:install-file` from the prebuilt quanton-velox-bundle JAR.
+         Plain test scope so the scalatest-forked JVM (useSystemClassLoader=false) picks it up. -->
+    <dependency>
+      <groupId>org.apache.gluten</groupId>
+      <artifactId>quanton-velox-bundle</artifactId>
+      <version>1.5.1-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Logging -->
     <dependency>

--- a/hudi-spark-datasource/hudi-spark/pom.xml
+++ b/hudi-spark-datasource/hudi-spark/pom.xml
@@ -153,11 +153,13 @@
   <dependencies>
 
     <!-- Gluten/Velox bundle (test only) for the data-type sweep. Installed into the local
-         Maven repo via `mvn install:install-file` from the prebuilt quanton-velox-bundle JAR.
-         Plain test scope so the scalatest-forked JVM (useSystemClassLoader=false) picks it up. -->
+         Maven repo via `mvn install:install-file` from the prebuilt, non-rebranded
+         gluten-velox-bundle JAR (upstream org.apache.gluten namespace; the quanton-rebranded
+         bundle has a native/Java JNI relocation mismatch that aborts the JVM at init).
+         Plain test scope so the forked test JVM picks it up. -->
     <dependency>
       <groupId>org.apache.gluten</groupId>
-      <artifactId>quanton-velox-bundle</artifactId>
+      <artifactId>gluten-velox-bundle</artifactId>
       <version>1.5.1-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>

--- a/hudi-spark-datasource/hudi-spark/pom.xml
+++ b/hudi-spark-datasource/hudi-spark/pom.xml
@@ -123,6 +123,17 @@
         </configuration>
       </plugin>
       <plugin>
+        <!-- The Gluten sweep target tests are JUnit @Test and run under surefire, not scalatest.
+             Gluten's columnar shuffle deserialization uses netty off-heap DirectByteBuffers, which
+             on JDK17 need io.netty.tryReflectionSetAccessible plus the jdk.internal.misc open/export.
+             Append them to the inherited argLine, which already carries the base add-opens set. -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>@{argLine} --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true</argLine>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.scalastyle</groupId>
         <artifactId>scalastyle-maven-plugin</artifactId>
       </plugin>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Wires the prebuilt Gluten/Velox bundle into the Hudi Spark functional-test harness so we can map which Spark/Hudi data types and operators Gluten offloads natively vs. falls back to vanilla Spark. Tracking: ENG-41979.

### Summary and Changelog

Test-only changes (no production code). Everything is gated behind `-Dhudi.test.gluten.enabled=true` (default off → the harness stays vanilla Spark).

- `HoodieClientTestUtils.getSparkConfForTest`: when the flag is set, inject the Gluten plugin + columnar configs (`org.apache.gluten.GlutenPlugin`, `org.apache.spark.shuffle.sort.ColumnarShuffleManager`, off-heap memory, `spark.gluten.sql.columnar.fallbackReporter=true`). The fallback reporter logs each non-offloadable operator with its reason — the sweep signal.
- `hudi-client/hudi-spark-client/pom.xml` + `hudi-spark-datasource/hudi-spark/pom.xml`: add `org.apache.gluten:gluten-velox-bundle` as a **test-scope** dependency (installed into the local Maven repo via `install:install-file`).
- `hudi-spark-datasource/hudi-spark/pom.xml`: append the JNI flags Gluten's columnar shuffle needs on JDK17 (`--add-opens`/`--add-exports` for `jdk.internal.misc` + `-Dio.netty.tryReflectionSetAccessible=true`) to the **surefire** `argLine`.

### How to run the tests with Gluten enabled

```bash
# 1. Install the gluten-velox-bundle JAR into the local Maven repo (one-time).
#    IMPORTANT: use the NON-rebranded bundle (org.apache.gluten namespace). The
#    quanton-rebranded bundle aborts the JVM at plugin init because its native
#    libgluten.so hardcodes org/apache/gluten/* JNI class paths while shading
#    relocated the Java classes to ai/onehouse/quanton/* (mismatch).
#    Pick the JAR matching your OS/arch (e.g. linux_aarch64).
GLUTEN_JAR=/path/to/gluten-velox-bundle-spark3.5_2.12-linux_aarch64-1.5.1-SNAPSHOT.jar
mvn install:install-file -Dfile=$GLUTEN_JAR \
  -DgroupId=org.apache.gluten -DartifactId=gluten-velox-bundle \
  -Dversion=1.5.1-SNAPSHOT -Dpackaging=jar

# 2. Build the upstream modules once (skip tests).
mvn -U install -pl hudi-spark-datasource/hudi-spark -am -DskipTests \
  -Pspark3.5 -Pscala-2.12 \
  -Drat.skip=true -Dcheckstyle.skip=true -Dscalastyle.skip=true

# 3. Run the targeted COW sweep with Gluten ENABLED.
export SPARK_LOCAL_IP=127.0.0.1
mvn test -pl hudi-spark-datasource/hudi-spark -Pspark3.5 -Pscala-2.12 \
  -Dhudi.test.gluten.enabled=true \
  -DskipUTs=true \
  -Dtest='TestCOWDataSource,TestColumnStatsIndex,TestBasicSchemaEvolution,TestParquetReaderCompatibility' \
  -DfailIfNoTests=false \
  -Drat.skip=true -Dcheckstyle.skip=true -Dscalastyle.skip=true \
  2>&1 | tee /tmp/hudi-gluten-run.log
```

Notes:
- `-Dhudi.test.gluten.enabled=true` is the on/off switch — **omit it to run the same tests on vanilla Spark**.
- `-DskipUTs=true` skips the unrelated scalatest suites; the target tests are JUnit `@Test` and run under surefire.
- MOR is excluded — Gluten supports **COW reads only** so far.
- Inspect what fell back: `grep -A1 'Validation failed for plan' /tmp/hudi-gluten-run.log` (reason is on the line after `due to:`).

### Impact

Test harness only. No production / runtime code paths changed. No public API or config impact.

### Risk Level

none — test-scope only, gated behind a default-off system property.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable